### PR TITLE
feat: adding current user

### DIFF
--- a/src/components/ChannelsList.tsx
+++ b/src/components/ChannelsList.tsx
@@ -1,49 +1,33 @@
 import React, { useContext } from "react";
 import ChannelContext, { Channel } from "../context/ChannelContext";
-import UserContext, { User } from "../context/UserContext";
 import { mockUsers } from "../data/mock";
+import { useCurrentUser } from "../hooks/useCurrentUser";
 
 export const ChannelsList: React.FC = () => {
   const { channels, dispatch, currentChannel } = useContext(ChannelContext);
-  const { currentUser, dispatch: userDispatch } = useContext(UserContext);
+  const { currentUser, setCurrentUser } = useCurrentUser();
 
   const handleChannelClick = (channel: Channel) => {
     dispatch({ type: "SET_CURRENT_CHANNEL", payload: channel });
   };
 
-  const handleUserClick = (user: User) => {
-    userDispatch({ type: "SET_CURRENT_USER", payload: user });
-  };
-
   return (
     <div className="flex flex-col w-1/3 border-r-2 bg-white">
       <div className="border-b-2 py-4 px-2">
-        <div className="relative inline-block w-full">
-          <select
-            className="block appearance-none w-full bg-white border border-gray-200 text-gray-700 py-3 px-4 pr-8 rounded leading-tight focus:outline-none focus:bg-white focus:border-gray-500"
-            value={currentUser?.id}
-            onChange={(e) => {
-              const selectedUser = mockUsers.find(
-                (user) => user.id === e.target.value
-              );
-              if (selectedUser) handleUserClick(selectedUser);
-            }}
-          >
-            {mockUsers.map((user) => (
-              <option key={user.id} value={user.id}>
-                {user.name}
-              </option>
-            ))}
-          </select>
-          <div className="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
-            <svg
-              className="fill-current h-4 w-4"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
+        <div className="flex flex-wrap justify-start">
+          {mockUsers.map((user) => (
+            <div
+              key={user.id}
+              onClick={() => setCurrentUser(user)}
+              className={`px-4 py-2 mr-2 mb-2 rounded cursor-pointer ${
+                currentUser?.id === user.id
+                  ? "bg-green-100 text-green-800"
+                  : "bg-gray-200 text-gray-700"
+              }`}
             >
-              <path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z" />
-            </svg>
-          </div>
+              {user.name}
+            </div>
+          ))}
         </div>
       </div>
       {channels.map((channel) => (

--- a/src/components/ChatBubble.tsx
+++ b/src/components/ChatBubble.tsx
@@ -2,16 +2,16 @@ import { useMutation } from "@apollo/client";
 import clsx from "clsx";
 import React, { useContext } from "react";
 import MessageContext, { Message } from "../context/MessageContext";
-import UserContext from "../context/UserContext";
 import { mockUsers } from "../data/mock";
 import { POST_MESSAGE } from "../graphQl/queries";
+import { useCurrentUser } from "../hooks/useCurrentUser";
 
 export interface ChatBubbleProps {
   message: Message;
 }
 
 export const ChatBubble: React.FC<ChatBubbleProps> = ({ message }) => {
-  const { currentUser } = useContext(UserContext);
+  const { currentUser } = useCurrentUser();
   const { dispatch } = useContext(MessageContext);
 
   const [postMessageMutation] = useMutation(POST_MESSAGE);

--- a/src/components/ChatSections.tsx
+++ b/src/components/ChatSections.tsx
@@ -1,19 +1,19 @@
-import React, { useContext } from "react";
+import React from "react";
 import { Message } from "../context/MessageContext";
-import UserContext from "../context/UserContext";
+
 import { ChatBubble } from "./ChatBubble";
 import { FETCH_MORE_MESSAGES, POST_MESSAGE } from "../graphQl/queries";
 import { useMutation, useQuery } from "@apollo/client";
 import { useMessages } from "../hooks/useMessages";
 import { useInputMessage } from "../hooks/useInputMessage";
 import { useScrollToBottom } from "../hooks/useScrollToBottom";
+import { useCurrentUser } from "../hooks/useCurrentUser";
 
 export const ChatSection: React.FC = () => {
   const { messages, currentChannel, dispatch } = useMessages();
   const { inputMessage, setInputMessage } = useInputMessage();
   const { showScrollToBottom } = useScrollToBottom();
-
-  const { currentUser } = useContext(UserContext);
+  const { currentUser } = useCurrentUser();
 
   const messagesEndRef = React.useRef<HTMLDivElement | null>(null);
   const olderMessagesEndRef = React.useRef<HTMLDivElement | null>(null);

--- a/src/components/MessageSection.tsx
+++ b/src/components/MessageSection.tsx
@@ -1,13 +1,14 @@
 import React, { useContext, useState } from "react";
 import ChannelContext from "../context/ChannelContext";
 import MessageContext, { Message } from "../context/MessageContext";
-import UserContext from "../context/UserContext";
+import { useCurrentUser } from "../hooks/useCurrentUser";
 import { ChatBubble } from "./ChatBubble";
 
 const MessageSection: React.FC = () => {
   const { messages, dispatch: messageDispatch } = useContext(MessageContext);
   const { currentChannel } = useContext(ChannelContext);
-  const { currentUser } = useContext(UserContext);
+  const { currentUser } = useCurrentUser();
+
   const [messageContent, setMessageContent] = useState("");
 
   const handleSendMessage = () => {

--- a/src/hooks/useCurrentUser.tsx
+++ b/src/hooks/useCurrentUser.tsx
@@ -1,0 +1,24 @@
+import { useContext, useEffect } from "react";
+import UserContext, { User } from "../context/UserContext";
+import { mockUsers } from "../data/mock";
+
+export const useCurrentUser = () => {
+  const { currentUser, dispatch } = useContext(UserContext);
+
+  useEffect(() => {
+    const storedUserId = localStorage.getItem("currentUser");
+    if (storedUserId) {
+      const storedUser = mockUsers.find((user) => user.id === storedUserId);
+      if (storedUser) {
+        dispatch({ type: "SET_CURRENT_USER", payload: storedUser });
+      }
+    }
+  }, [dispatch]);
+
+  const setCurrentUser = (user: User) => {
+    localStorage.setItem("currentUser", user.id);
+    dispatch({ type: "SET_CURRENT_USER", payload: user });
+  };
+
+  return { currentUser, setCurrentUser };
+};


### PR DESCRIPTION
Title: Refactor ChannelsList component to use custom useCurrentUser hook

Description:
In this PR, we have introduced a new custom hook called useCurrentUser to improve the modularity and readability of the ChannelsList component. The custom hook is responsible for retrieving the current user from local storage and providing a function to change the current user.

The main changes include:

Created a new file useCurrentUser.ts that contains the useCurrentUser custom hook. This hook includes a useEffect to load the current user from local storage and a function setCurrentUser to update the current user in the context and local storage.

Refactored the ChannelsList component to use the useCurrentUser hook. This allowed us to simplify the component by removing the useEffect related to the user and replacing the handleUserClick function with the setCurrentUser function provided by the hook.

Updated the user selection UI in the ChannelsList component to use modern tabs instead of a dropdown. The chosen user tab is now highlighted, and the user selection is stored in local storage so that it persists across page reloads.

These changes will make the code more maintainable and easier to understand, while also enhancing the user experience with a more modern UI for user selection.